### PR TITLE
chore(package): update bootprint-openapi to version 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "bootprint": "0.10.0",
-    "bootprint-openapi": "0.17.1",
+    "bootprint-openapi": "1.0.1",
     "coveralls": "2.11.15",
     "cross-conf-env": "1.0.7",
     "dockerode": "2.3.1",


### PR DESCRIPTION
Closes #32

https://greenkeeper.io/