### PR TITLE
Commit transaction before sending http response

### DIFF
--- a/src/apps/adminInvitation.js
+++ b/src/apps/adminInvitation.js
@@ -58,12 +58,10 @@ app.post('/', function(req, res){
            })
            .then(function(){
                return invitation.destroy();
-           })
-           .then(function(){
-               return res.status(204).end();
            });
        });
     })
+    .then(function(){ res.status(204).json(); })
     .catch(req.next);
 });
 

--- a/src/apps/registration.js
+++ b/src/apps/registration.js
@@ -54,11 +54,9 @@ app.post('/', function(req, res){
                         tenantId: tenantId
                     })
                 );
-            })
-            .then(function(){
-                return res.status(204).end();
             });
         })
+        .then(function(){ res.status(204).json(); })
         .catch(req.next);
 });
 


### PR DESCRIPTION
Sometimes the response is received by the client before the transaction is committed and it has time to send another request to cloudpass. Cloudpass then processes this request before the transaction of the previous request is committed (!) an this leads to unexpected results.